### PR TITLE
allow linking to a quick start scenario

### DIFF
--- a/index.html
+++ b/index.html
@@ -2132,6 +2132,7 @@ Current version: 15
 				//read the url params, and autoload a shared story if found
 				const urlParams = new URLSearchParams(window.location.search);
 				const foundStory = urlParams.get('s');
+				const foundScenario = urlParams.get('scenario');
 				const nofiltermode = urlParams.get('nofilter');
 				if (nofiltermode) {
 					horde_img_filter_enabled = false;
@@ -2147,6 +2148,15 @@ Current version: 15
 					}
 					//purge url params
 					window.history.replaceState(null, null, window.location.pathname);
+				} else if (foundScenario && foundScenario != "") {
+					display_scenarios();
+					document.getElementById("scenariosearch").value = escapeHtml(foundScenario);
+					scenario_search();
+					const found = scenario_db.find(m => m.title.toLowerCase() == foundScenario.trim().toLowerCase());
+					if (found !== undefined) {
+						temp_scenario = found;
+						preview_temp_scenario();
+					}
 				}else{
 					if(popup_aiselect)
 					{


### PR DESCRIPTION
Allow linking straight to a scenario without having to use a "scary" `?s=<base64>` url.

For example something that I could use in Discord:
https://lite.koboldai.net/?scenario=KoboldGPT