### PR TITLE
fix support for correct protocol on https

### DIFF
--- a/index.html
+++ b/index.html
@@ -2498,10 +2498,13 @@ Current version: 20
 		if (localflag)
 		{
 			localmode = true;
-			let inputport = urlParams.get('port');
 			if (window.location.port && window.location.port != 80 && window.location.port != 443) {
 				localmodeport = window.location.port;
 			}
+			if(!window.location.port && window.location.protocol.includes('https')) {
+				localmodeport = 443;
+			}
+			let inputport = urlParams.get('port');
 			if (inputport) {
 				localmodeport = parseInt(inputport);
 			}
@@ -2593,7 +2596,7 @@ Current version: 20
 		if (localmode) {
 			document.getElementById("customapidropdown").value = 0;
 			let protocol = "http://";
-			if(window.location.protocol.includes('https') && localmodeport==443)
+			if(window.location.protocol.includes('https'))
 			{
 				protocol = "https://";
 			}


### PR DESCRIPTION
For local requests via https and port 443 window.location.port is empty(''). Also with https the port can be different, not just 443.